### PR TITLE
Update cutpursuit.cpp

### DIFF
--- a/src/cutpursuit.cpp
+++ b/src/cutpursuit.cpp
@@ -69,13 +69,14 @@ PyObject * cutpursuit(const bpn::ndarray & obs, const bpn::ndarray & source, con
     const uint32_t * source_data = reinterpret_cast<uint32_t*>(source.get_data());
     const uint32_t * target_data = reinterpret_cast<uint32_t*>(target.get_data());
     const float * edge_weight_data = reinterpret_cast<float*>(edge_weight.get_data());
-    //std::vector< std::vector<float> > solution(n_ver, std::vector<float>(n_obs));
-    float solution [n_ver * n_obs];
+//    float solution [n_ver * n_obs];
+    std::vector<float> solution(n_ver * n_obs, 0.0f);
     std::vector<float> node_weight(n_ver, 1.0f);
     std::vector<uint32_t> in_component(n_ver,0);
     std::vector< std::vector<uint32_t> > components(1,std::vector<uint32_t>(1,0.f));
     CP::cut_pursuit<float>(n_ver, n_edg, n_obs, obs_data, source_data, target_data, edge_weight_data, &node_weight[0]
-             , solution, in_component, components, lambda, 1.f, 2.f, 2.f);
+             , solution.data(), in_component, components, lambda, 1.f, 2.f, 2.f);
+//    delete[]solution
     return to_py_tuple::convert(Custom_tuple(components, in_component));
 }
 BOOST_PYTHON_MODULE(libcp)


### PR DESCRIPTION
Initializing the solution as a float array may causes a segfault when n_ver * n_obs gets too large.
This segfault is caused by the implicit size limit for stack objects.
Using vectors is way safer here. You can access vectors like arrays using the .data() function. Using a vector of vectors (as proposed by the to-delte comment) isn't necessary here.

Moreover, the original float array never got deleted, which may causes a memory leak.