### PR TITLE
Matlab MEX interface compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ Eu = 0:(n_nodes-2);
 Ev = 1:(n_nodes-1);
 edge_weight = ones(numel(Eu),1);
 node_weight = ones(n_nodes,1);
-  
-[solution, in_component, components] = L0_cut_pursuit_segmentation(single(y), uint32(Eu), uint32(Ev), single(.1)...
-    , single(edge_weight), single(node_weight), 1, 2, 2);
+lambda = .1;
+mode = 1;
+cutoff = 0;
+weigth_decay = 0;
+speedmode = 2;
+verbosity = 2;
+
+[solution, in_component, components] = L0_cut_pursuit_segmentation(single(y),...
+        uint32(Eu), uint32(Ev), single(lambda),...
+        single(edge_weight), single(node_weight), mode, cutoff, speedmode,...
+        weigth_decay, verbosity);
 
 subplot(3,1,1)
 imagesc(repmat(y, [1 1 1]))

--- a/mex/L0_cut_pursuit.cpp
+++ b/mex/L0_cut_pursuit.cpp
@@ -60,10 +60,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     const float * edgeWeight  = (float *) mxGetData(prhs[4]);
     const float * nodeWeight  = (float *) mxGetData(prhs[5]);
     const float mode          = (float) mxGetScalar(prhs[6]);
-    const float speed         = (float) mxGetScalar(prhs[7]);
-    const float verbose       = (float) mxGetScalar(prhs[8]);    
+    const uint32_t cutoff     = (uint32_t) mxGetScalar(prhs[7]);
+    const float speed         = (float) mxGetScalar(prhs[8]);
+    const float weight_decay  = (float) mxGetScalar(prhs[9]);    
+    const float verbose       = (float) mxGetScalar(prhs[10]);    
     float * solution          = (float *) mxGetData(plhs[0]);
 
     CP::cut_pursuit<float>(nNod, nEdg, nObs, y
-      , Eu, Ev, edgeWeight, nodeWeight, solution, lambda, mode, speed,verbose);
+      , Eu, Ev, edgeWeight, nodeWeight, solution, lambda, cutoff,  mode, speed, weight_decay, verbose);
 }

--- a/mex/L0_cut_pursuit_segmentation.cpp
+++ b/mex/L0_cut_pursuit_segmentation.cpp
@@ -73,8 +73,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     const std::vector<float> edge_weight((float*)mxGetData(prhs[4]), (float*)mxGetData(prhs[4])+nEdg);
     const std::vector<float> node_weight((float*)mxGetData(prhs[5]), (float*)mxGetData(prhs[5])+n_nodes);
     const float mode          = (float) mxGetScalar(prhs[6]); //fidelity
-    const float speed         = (float) mxGetScalar(prhs[7]); //speed mode
-    const float verbose       = (float) mxGetScalar(prhs[8]); //verbosity*/
+    const uint32_t cutoff     = (uint32_t) mxGetScalar(prhs[7]); //cut off
+    const float speed         = (float) mxGetScalar(prhs[8]); //speed mode
+    const float weight_decay  = (float) mxGetScalar(prhs[9]); //weight decay*/
+    const float verbose       = (float) mxGetScalar(prhs[10]); //verbosity*/
     //--fill the observation----
     const float *observation_array = (float*) mxGetData(prhs[0]);
     std::vector< std::vector<float> > solution(n_nodes);
@@ -106,7 +108,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             , in_component, components
             , n_nodes_red, n_edges_red,  Eu_red, Ev_red
             , edge_weight_red,node_weight_red
-            ,lambda, mode, speed,verbose);
+            ,lambda, cutoff, mode, speed, weight_decay, verbose);
     }
     if (true)
     {


### PR DESCRIPTION
When I tried to compile the mex files as provided in the Readme I ran into an error saying that the number of arguments of the function call in `L0_cut_pursuit_segmentation.cpp` and `L0_cut_pursuit.cpp` did not match. I found out that the arguments `cutoff` and `weight_decay` were not set. I just changed that. Additionally, I had to fix the example in the readme and also provided more variables. I find this way more easy to understand the call than put in numbers. :) Please check this merge request. 

Best Regrads
Fjedor

BTW: This is my first pull request so if something did not work as expected please contact me :)